### PR TITLE
time limit

### DIFF
--- a/cartex/include/cartex/common/options.hpp
+++ b/cartex/include/cartex/common/options.hpp
@@ -138,6 +138,8 @@ class options
         return add(name, description, variable, default_str_values, default_str_values.size());
     }
 
+    std::string help_message(std::string const& command) const;
+
   private:
     options& add(std::string const& name, std::string const& description)
     {
@@ -153,8 +155,6 @@ class options
         m_options.push_back({name, description, variable, default_values, nargs});
         return *this;
     }
-
-    std::string help_message(std::string const& command) const;
 };
 
 } // namespace cartex

--- a/cartex/include/cartex/common/options.hpp
+++ b/cartex/include/cartex/common/options.hpp
@@ -138,8 +138,6 @@ class options
         return add(name, description, variable, default_str_values, default_str_values.size());
     }
 
-    std::string help_message(std::string const& command) const;
-
   private:
     options& add(std::string const& name, std::string const& description)
     {
@@ -155,6 +153,8 @@ class options
         m_options.push_back({name, description, variable, default_values, nargs});
         return *this;
     }
+
+    std::string help_message(std::string const& command) const;
 };
 
 } // namespace cartex

--- a/cartex/include/cartex/common/sync_loop.hpp
+++ b/cartex/include/cartex/common/sync_loop.hpp
@@ -1,0 +1,60 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#pragma once
+
+#include <mpi.h>
+#include <cstddef>
+#include <algorithm>
+#include <chrono>
+#include <atomic>
+
+namespace cartex
+{
+class sync_loop
+{
+  private:
+    using clock_type = std::chrono::high_resolution_clock;
+    using time_point_type = std::chrono::time_point<clock_type>;
+
+  private:
+    MPI_Comm                  m_comm;
+    int                       m_rank;
+    unsigned int              m_num_threads;
+    std::atomic<unsigned int> m_count_up;
+    std::atomic<unsigned int> m_count_down;
+    double                    m_dt;
+
+  public:
+    sync_loop(MPI_Comm comm, unsigned int num_threads = 1u) noexcept;
+    sync_loop(sync_loop const&) = delete;
+    sync_loop(sync_loop&&) = delete;
+
+    template<typename Function>
+    std::size_t repeat_for(Function&& f, double seconds, unsigned int thread_id = 0,
+        std::size_t min_iterations = 1, std::size_t increment = 1) noexcept
+    {
+        const auto tp = clock_type::now();
+        increment = std::max((std::size_t)1, increment);
+        std::size_t i = 0;
+        do
+        {
+            for (std::size_t j = 0; j < increment; ++j) f();
+            i += increment;
+        } while (i < min_iterations || elapsed(tp, thread_id) < seconds);
+        return i;
+    }
+
+  private:
+    double elapsed(time_point_type const& tp, unsigned int thread_id) noexcept;
+    void   bcast(double& dt, unsigned int thread_id) noexcept;
+};
+} // namespace cartex

--- a/cartex/include/cartex/runtime/runtime.hpp
+++ b/cartex/include/cartex/runtime/runtime.hpp
@@ -19,6 +19,7 @@
 #include <cartex/common/memory.hpp>
 #include <cartex/common/options.hpp>
 #include <cartex/decomposition/decomposition.hpp>
+#include <cartex/common/sync_loop.hpp>
 
 namespace cartex
 {
@@ -34,6 +35,8 @@ class runtime
     const int                             m_rank;
     const int                             m_size;
     const int                             m_num_reps;
+    bool                                  m_use_timer;
+    double                                m_time;
     const int                             m_num_threads;
     const bool                            m_mt;
     const int                             m_num_fields;
@@ -44,6 +47,7 @@ class runtime
     std::vector<domain_type>              m_domains;
     std::vector<std::vector<memory_type>> m_raw_fields;
     std::mutex                            m_mutex;
+    sync_loop                             m_loop;
     class impl;
     friend class impl;
     std::unique_ptr<impl> m_impl;

--- a/cartex/src/bin/benchmark.cpp
+++ b/cartex/src/bin/benchmark.cpp
@@ -22,7 +22,8 @@ main(int argc, char** argv)
     auto opts = cartex::options()
         ("domain",        "local domain size (default: 64 64 64)", "X Y Z",    3)
         ("global-domain", "global domain size",                    "X Y Z",    3)
-        ("nrep",          "number of repetitions",                 "r",        {10})
+        ("nrep",          "number of repetitions",                 "r",        1)
+        ("time",          "execution time",                        "t",        1)
         ("nfields",       "number of fields",                      "n",        {1})
         ("halo",          "halo size",                             "h",        {1})
         ("MPICart",       "MPI cartesian global grid",             "NX NY NZ", 3)
@@ -38,6 +39,13 @@ main(int argc, char** argv)
         ("check",         "check results");
     /* clang-format on */
     const auto options = cartex::runtime::add_options(opts).parse(argc, argv);
+
+    if (!options.has("nrep") && !options.has("time"))
+    {
+        std::cerr << "Error: either --nrep or --time must be specified" << std::endl;
+        std::cout << opts.help_message(argv[0]);
+        std::exit(1);
+    }
 
     const auto threads = options.get<std::array<int, 3>>("thread");
     const auto num_threads = threads[0] * threads[1] * threads[2];

--- a/cartex/src/bin/benchmark.cpp
+++ b/cartex/src/bin/benchmark.cpp
@@ -22,7 +22,7 @@ main(int argc, char** argv)
     auto opts = cartex::options()
         ("domain",        "local domain size (default: 64 64 64)", "X Y Z",    3)
         ("global-domain", "global domain size",                    "X Y Z",    3)
-        ("nrep",          "number of repetitions",                 "r",        1)
+        ("nrep",          "number of repetitions (default: 10)",   "r",        1)
         ("time",          "execution time",                        "t",        1)
         ("nfields",       "number of fields",                      "n",        {1})
         ("halo",          "halo size",                             "h",        {1})
@@ -39,13 +39,6 @@ main(int argc, char** argv)
         ("check",         "check results");
     /* clang-format on */
     const auto options = cartex::runtime::add_options(opts).parse(argc, argv);
-
-    if (!options.has("nrep") && !options.has("time"))
-    {
-        std::cerr << "Error: either --nrep or --time must be specified" << std::endl;
-        std::cout << opts.help_message(argv[0]);
-        std::exit(1);
-    }
 
     const auto threads = options.get<std::array<int, 3>>("thread");
     const auto num_threads = threads[0] * threads[1] * threads[2];
@@ -200,8 +193,7 @@ main(int argc, char** argv)
         else
         {
             cartex::thread_pool tp(num_threads);
-            for (int j = 0; j < num_threads; ++j)
-                tp.schedule(j, [&r](int j) { r.exchange(j); });
+            for (int j = 0; j < num_threads; ++j) tp.schedule(j, [&r](int j) { r.exchange(j); });
         }
 
         CARTEX_CHECK_MPI_RESULT(MPI_Barrier(decomp_ptr->mpi_comm()));

--- a/cartex/src/common/CMakeLists.txt
+++ b/cartex/src/common/CMakeLists.txt
@@ -5,3 +5,8 @@ target_link_libraries(options PRIVATE cartex)
 compile_as_cuda(thread_pool.cpp)
 add_library(thread_pool thread_pool.cpp)
 target_link_libraries(thread_pool PRIVATE cartex)
+
+compile_as_cuda(sync_loop.cpp)
+add_library(sync_loop sync_loop.cpp)
+target_link_libraries(sync_loop PRIVATE cartex)
+target_link_libraries(sync_loop PRIVATE MPI::MPI_CXX)

--- a/cartex/src/common/sync_loop.cpp
+++ b/cartex/src/common/sync_loop.cpp
@@ -1,0 +1,55 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <cartex/common/sync_loop.hpp>
+
+namespace cartex
+{
+sync_loop::sync_loop(MPI_Comm comm, unsigned int num_threads) noexcept
+: m_comm{comm}
+, m_num_threads{num_threads}
+, m_count_up{0}
+, m_count_down{num_threads}
+{
+    MPI_Comm_rank(m_comm, &m_rank);
+}
+
+double
+sync_loop::elapsed(time_point_type const& tp, unsigned int thread_id) noexcept
+{
+    double dt = 1.0e-9 * std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             sync_loop::clock_type::now() - tp)
+                             .count();
+    if (thread_id == 0) MPI_Bcast(&dt, 1, MPI_DOUBLE, 0, m_comm);
+    bcast(dt, thread_id);
+    return dt;
+}
+
+void
+sync_loop::bcast(double& dt, unsigned int thread_id) noexcept
+{
+    if (thread_id == 0) m_dt = dt;
+    auto ex_u = thread_id;
+    while (!m_count_up.compare_exchange_weak(ex_u, ex_u + 1, std::memory_order_relaxed))
+        ex_u = thread_id;
+    if (ex_u == m_num_threads - 1) m_count_up.store(0);
+    else
+        while (m_count_up != 0) {}
+    dt = m_dt;
+    unsigned int ex_d = m_count_down;
+    while (!m_count_down.compare_exchange_weak(ex_d, ex_d - 1, std::memory_order_relaxed))
+        ex_d = m_count_down;
+    if (ex_d == 1) m_count_down.store(m_num_threads);
+    else
+        while (m_count_down != m_num_threads) {}
+}
+
+} // namespace cartex

--- a/cartex/src/runtime/CMakeLists.txt
+++ b/cartex/src/runtime/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(MPI REQUIRED COMPONENTS CXX)
 
 add_library(runtime)
 target_link_libraries(runtime PRIVATE cartex)
+target_link_libraries(runtime PRIVATE sync_loop)
 target_link_libraries(runtime PRIVATE MPI::MPI_CXX)
 target_link_libraries(runtime PRIVATE HWCART::hwcart)
 

--- a/cartex/src/runtime/runtime.cpp
+++ b/cartex/src/runtime/runtime.cpp
@@ -52,17 +52,14 @@ runtime::exchange(int j)
     std::size_t reps = 0;
     if (m_use_timer)
     {
-        // warm up
         m_loop.repeat_for(warm_up_step, 0.1 * m_time, j, 50, 10);
-        // main loop
         reps = m_loop.repeat_for(main_step, 0.9 * m_time, j, m_num_reps, 100);
     }
     else
     {
-        // warm up
         for (int t = 0; t < 50; ++t) warm_up_step();
-        // main loop
         for (int t = 0; t < m_num_reps; ++t) main_step();
+        reps = m_num_reps;
     }
 
     if (j == 0)

--- a/cartex/src/runtime/runtime_inc.cpp
+++ b/cartex/src/runtime/runtime_inc.cpp
@@ -15,7 +15,9 @@ runtime::runtime(const options_values& options, decomposition& decomp_)
 : m_decomposition(decomp_)
 , m_rank(m_decomposition.rank())
 , m_size(m_decomposition.size())
-, m_num_reps{options.get<int>("nrep")}
+, m_num_reps{options.has("time") ? options.get_or("nrep", 0) : options.get_or("nrep", 10)}
+, m_use_timer{options.has("time")}
+, m_time{options.get_or("time", 0.0)}
 , m_num_threads(m_decomposition.threads_per_rank())
 , m_mt(m_num_threads > 1)
 , m_num_fields{options.get<int>("nfields")}
@@ -25,6 +27,7 @@ runtime::runtime(const options_values& options, decomposition& decomp_)
 , m_offset{m_halos[0], m_halos[2], m_halos[4]}
 , m_domains{decomp_.domains()}
 , m_raw_fields(m_num_threads)
+, m_loop(m_decomposition.mpi_comm(), m_num_threads)
 , m_impl{std::make_unique<impl>(*this, options)}
 {
 }

--- a/run/utils/analyse.xml
+++ b/run/utils/analyse.xml
@@ -25,6 +25,7 @@
         -->
 
         <!--<pattern name="pat_fp" type="float">(([-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?)</pattern>-->
+        <pattern name="n_repetitions" type="int">repetitions[ ]+${jube_pat_int}</pattern>
         <pattern name="load"          type="float">load \(bytes\)[ ]+${pat_fp}</pattern>
         <pattern name="t_elapsed"     type="float">elapsed \(s\)[ ]+${pat_fp}</pattern>
         <pattern name="t_mean"        type="float">mean \(s\)[ ]+${pat_fp}</pattern>


### PR DESCRIPTION
- added class for running until time limit is reached
- time limit can be specified as cmd-line argument `--time`
- 10% of time used for warm up, rest for main loop
- works with multiple ranks/threads by broadcasting elapsed time from time to time
- reports the actual number of iterations it has run
- if both `--time` and `--nreps` are specified, `--nreps` is treated as minimum number of iterations
